### PR TITLE
Update litlecc.phtml

### DIFF
--- a/app/design/frontend/base/default/template/litle/form/litlecc.phtml
+++ b/app/design/frontend/base/default/template/litle/form/litlecc.phtml
@@ -39,7 +39,7 @@ Validation.creditCartTypes.set('DC', [new RegExp('^3(?:0[0-5]|[68][0-9])[0-9]{11
 <?php
 $_time =  date('ymdHis');
 $_session =  Mage::getModel("core/session")->getEncryptedSessionId();
-$_id = $_time . substr($_session,13);
+$_id = $_time . substr($_session,0,12);
 
 ?>
 <?php $_code=$this->getMethodCode() ?>


### PR DESCRIPTION
Modifying length of order IDs generated from the Magento session ID.  By changing the substr() call on line 42, the length of the orderID is no more than 25 characters.